### PR TITLE
Use realpath to get the DEV_DIR path

### DIFF
--- a/create_dev_env.sh
+++ b/create_dev_env.sh
@@ -27,14 +27,13 @@ debug() {
 
 # Parameter
 if [ $# -eq 1 ]; then
-    DEV_DIR=$1
+    DEV_DIR=$(realpath "$1")
 else
     echo "ERROR: Invalid Arguments"
     echo "Usage: ./create_dev_env.sh <base directory>"
     exit 1
 fi
-
-echo "Creating development environment directory: $1"
+echo "Creating development environment directory: $DEV_DIR"
 mkdir -p ${DEV_DIR}
 cd ${DEV_DIR}
 


### PR DESCRIPTION
Doing this avoids issues with PYTHONPATH and setuptools.
I've only tested this on Ubuntu 17.04, but realpath is part of
GNU Coreutils, so should be available.